### PR TITLE
Use proper path handling in localChat handler

### DIFF
--- a/src/FBLocalChatRoutes.js
+++ b/src/FBLocalChatRoutes.js
@@ -104,7 +104,7 @@ const FBLocalChatRoutes = (router: Router, Bot: Object): Router => {
 
   router.get('/localChat/*', (req, res) => {
     const dir = path.join(path.dirname(__filename), '..', 'localChatWeb');
-    var filePath = req.url.replace('/localChat', '');
+    var filePath = path.join(...(path.normalize(req.path).split(path.sep).filter(leaf => leaf !== 'localChat')));
     if (filePath !== '/') {
       res.sendFile(filePath, {root: dir});
       return
@@ -112,7 +112,7 @@ const FBLocalChatRoutes = (router: Router, Bot: Object): Router => {
     const baseURL = req.baseUrl;
 
     // return html
-    fs.readFile(dir + '/index.html', 'utf8', (err, data) => {
+    fs.readFile(path.join(dir, 'index.html'), 'utf8', (err, data) => {
       console.log(err);
       if (err) {
         res.send('ERROR');


### PR DESCRIPTION
Ran into a rather obscure bug where the base path where my project was was causing issues with the `localChatWeb` portion of the chat bot.

This patch makes the `localChat` GET verbs use proper path handling and whatnot - and ultimately fixes several problems.